### PR TITLE
Update tests

### DIFF
--- a/tests/testthat/test_dfSearch-get_eigen_DFoverlay_list.R
+++ b/tests/testthat/test_dfSearch-get_eigen_DFoverlay_list.R
@@ -2,7 +2,7 @@ context('get_eigen_DFoverlay_list()')
 
 ## set seed and reset on exit
 set.seed(seed=42)
-on.exit(set.seed(seed=NULL)) 
+on.exit(set.seed(seed=NULL))
 
 
 ## Input and expected data
@@ -16,10 +16,10 @@ input_eigen <- evaluate_promise(get_eigen_spline(inputData=input_inputData, ind=
 
 
 test_that('default values, change df', {
-  
+
   # results
   result_DFoverlay  <- get_eigen_DFoverlay_list(input_eigen,manualDf=3,nPC=NA,step=NA,showPt=TRUE,autofit=TRUE)
-  
+
   # Check plot properties
   expect_equal(length(result_DFoverlay), 3)
   # plot #1
@@ -27,14 +27,14 @@ test_that('default values, change df', {
   expect_equal(result_DFoverlay[[1]]$labels$title, "Fit PC 1 varExp=71.1% - df=3 - Auto-df=2")
   expect_equal(result_DFoverlay[[1]]$labels$x, "Time")
   expect_equal(result_DFoverlay[[1]]$labels$y, "Projection")
-  expect_equal(length(result_DFoverlay[[1]]), 9)
+  expect_equal(length(result_DFoverlay[[1]]), length(ggplot2::ggplot()))
 })
 
 test_that('change nPC', {
-  
+
   # results
   result_DFoverlay  <- get_eigen_DFoverlay_list(input_eigen,manualDf=3,nPC=2,step=NA,showPt=TRUE,autofit=TRUE)
-  
+
   # Check plot properties
   expect_equal(length(result_DFoverlay), 2)
   # plot #1
@@ -42,15 +42,15 @@ test_that('change nPC', {
   expect_equal(result_DFoverlay[[1]]$labels$title, "Fit PC 1 varExp=71.1% - df=3 - Auto-df=2")
   expect_equal(result_DFoverlay[[1]]$labels$x, "Time")
   expect_equal(result_DFoverlay[[1]]$labels$y, "Projection")
-  expect_equal(length(result_DFoverlay[[1]]), 9)
+  expect_equal(length(result_DFoverlay[[1]]), length(ggplot2::ggplot()))
 })
 
 test_that('change step', {
   # doesn't change the results that can be accessed
-  
+
   # results
   result_DFoverlay  <- get_eigen_DFoverlay_list(input_eigen,manualDf=3,nPC=NA,step=1,showPt=TRUE,autofit=TRUE)
-  
+
   # Check plot properties
   expect_equal(length(result_DFoverlay), 3)
   # plot #1
@@ -58,15 +58,15 @@ test_that('change step', {
   expect_equal(result_DFoverlay[[1]]$labels$title, "Fit PC 1 varExp=71.1% - df=3 - Auto-df=2")
   expect_equal(result_DFoverlay[[1]]$labels$x, "Time")
   expect_equal(result_DFoverlay[[1]]$labels$y, "Projection")
-  expect_equal(length(result_DFoverlay[[1]]), 9)
+  expect_equal(length(result_DFoverlay[[1]]), length(ggplot2::ggplot()))
 })
 
 test_that('no showPt', {
   # doesn't change the results that can be accessed
-  
+
   # results
   result_DFoverlay  <- get_eigen_DFoverlay_list(input_eigen,manualDf=3,nPC=NA,step=NA,showPt=FALSE,autofit=TRUE)
-  
+
   # Check plot properties
   expect_equal(length(result_DFoverlay), 3)
   # plot #1
@@ -74,14 +74,14 @@ test_that('no showPt', {
   expect_equal(result_DFoverlay[[1]]$labels$title, "Fit PC 1 varExp=71.1% - df=3 - Auto-df=2")
   expect_equal(result_DFoverlay[[1]]$labels$x, "Time")
   expect_equal(result_DFoverlay[[1]]$labels$y, "Projection")
-  expect_equal(length(result_DFoverlay[[1]]), 9)
+  expect_equal(length(result_DFoverlay[[1]]), length(ggplot2::ggplot()))
 })
 
 test_that('no autofit', {
-  
+
   # results
   result_DFoverlay  <- get_eigen_DFoverlay_list(input_eigen,manualDf=3,nPC=NA,step=NA,showPt=TRUE,autofit=FALSE)
-  
+
   # Check plot properties
   expect_equal(length(result_DFoverlay), 3)
   # plot #1
@@ -89,7 +89,7 @@ test_that('no autofit', {
   expect_equal(result_DFoverlay[[1]]$labels$title, "Fit PC 1 varExp=71.1% - df=3")
   expect_equal(result_DFoverlay[[1]]$labels$x, "Time")
   expect_equal(result_DFoverlay[[1]]$labels$y, "Projection")
-  expect_equal(length(result_DFoverlay[[1]]), 9)
+  expect_equal(length(result_DFoverlay[[1]]), length(ggplot2::ggplot()))
 })
 
 

--- a/tests/testthat/test_dfSearch-plot_nbTP_histogram.R
+++ b/tests/testthat/test_dfSearch-plot_nbTP_histogram.R
@@ -2,7 +2,7 @@ context('plot_nbTP_histogram()')
 
 ## set seed and reset on exit
 set.seed(seed=42)
-on.exit(set.seed(seed=NULL)) 
+on.exit(set.seed(seed=NULL))
 
 
 ## Input and expected data
@@ -27,28 +27,28 @@ test_that('default values', {
 
   # results (output, warnings and messages)
   result_nbTPHisto  <- plot_nbTP_histogram(input_eigen, dfCutOff=NA)
-  
+
   # Check plot properties
   expect_true(ggplot2::is.ggplot(result_nbTPHisto))
   expect_equal(result_nbTPHisto$labels$title, "Trajectories with #TP < df will be rejected")
   expect_equal(result_nbTPHisto$labels$x, "Number of time-points")
   expect_equal(result_nbTPHisto$labels$y, "Number of trajectories with corresponding TP")
   expect_equal(result_nbTPHisto$data, expected_data)
-  expect_equal(length(result_nbTPHisto), 9)
+  expect_equal(length(result_nbTPHisto), length(ggplot2::ggplot()))
 })
 
 test_that('different number of time-points per spline', {
-  
+
   # results (output, warnings and messages)
   result_nbTPHisto_2  <- plot_nbTP_histogram(input_eigen_2, dfCutOff=NA)
-  
+
   # Check plot properties
   expect_true(ggplot2::is.ggplot(result_nbTPHisto_2))
   expect_equal(result_nbTPHisto_2$labels$title, "Trajectories with #TP < df will be rejected")
   expect_equal(result_nbTPHisto_2$labels$x, "Number of time-points")
   expect_equal(result_nbTPHisto_2$labels$y, "Number of trajectories with corresponding TP")
   expect_equal(result_nbTPHisto_2$data, expected_data_2)
-  expect_equal(length(result_nbTPHisto_2), 9)
+  expect_equal(length(result_nbTPHisto_2), length(ggplot2::ggplot()))
 })
 
 test_that('change dfCuttOff', {
@@ -56,15 +56,15 @@ test_that('change dfCuttOff', {
   # expected data
   tmp_data          <- expected_data
   tmp_data$colFill  <- 1
-  
+
   # results (output, warnings and messages)
   result_nbTPHisto  <- plot_nbTP_histogram(input_eigen, dfCutOff=3)
-  
+
   # Check plot properties
   expect_true(ggplot2::is.ggplot(result_nbTPHisto))
   expect_equal(result_nbTPHisto$labels$title, "Trajectories with #TP < df (0%) will be rejected")
   expect_equal(result_nbTPHisto$labels$x, "Number of time-points / df cut-off")
   expect_equal(result_nbTPHisto$labels$y, "Number of trajectories with corresponding TP")
   expect_equal(result_nbTPHisto$data, tmp_data)
-  expect_equal(length(result_nbTPHisto), 9)
+  expect_equal(length(result_nbTPHisto), length(ggplot2::ggplot()))
 })


### PR DESCRIPTION
Hello there,

We have been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break santaR.

Several tests had expectations that the result of plot objects had length 9. This assumption no longer holds in the new version of ggplot2, so this PR updates these tests to test for the same length as `ggplot()` results.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of February. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. We hope that this PR might help santaR get out a fix if necessary.